### PR TITLE
Disallow "completed, move to next queue" on placeholders

### DIFF
--- a/src/app/admin/queue-view/queue-view.component.html
+++ b/src/app/admin/queue-view/queue-view.component.html
@@ -46,7 +46,7 @@
               <div class="sort-handle" dnd-sortable-handle title="Drag to reorder">
                 <app-icon name="arrow_move"></app-icon>
               </div>
-              <button (click)="markCompleted(i)" title="Completed, move on to next queue">
+              <button [disabled]="queueGroup.pending" (click)="markCompleted(i)" title="Completed, move on to next queue">
                 <app-icon name="icon_box-checked"></app-icon>
               </button>
               <button (click)="startEdit(i)" title="Edit">

--- a/src/app/admin/queue-view/queue-view.component.scss
+++ b/src/app/admin/queue-view/queue-view.component.scss
@@ -107,7 +107,14 @@
           padding: 5px 10px;
           margin-right: 0px;
 
-          &:hover {
+          &:disabled {
+            opacity: 0.3;
+
+            &:hover {
+              cursor: default;
+            }
+          }
+          &:hover:not(:disabled) {
             background: #cccccc;
           }
         }


### PR DESCRIPTION
Disables the button for placeholders in the list

Closes #24